### PR TITLE
Replace `sklearn` dependency with `scikit-learn`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='scattertext',
       install_requires=[
 	      'numpy',
 	      'scipy',
-	      'sklearn',
+	      'scikit-learn',
 	      'pandas',
 	      #'spacy',
 	      #'jieba',


### PR DESCRIPTION
`sklearn` isn't the package you're looking for; as https://pypi.python.org/pypi/sklearn politely notes, you should "Use [scikit-learn](https://pypi.python.org/pypi/scikit-learn/) instead."

It's unfortunate that the names of Python packages have nothing to do with their import names, besides convention :(