### PR TITLE
Fix FutureWarning: read_table is deprecated, use read_csv instead, pa…

### DIFF
--- a/scattertext/frequencyreaders/DefaultBackgroundFrequencies.py
+++ b/scattertext/frequencyreaders/DefaultBackgroundFrequencies.py
@@ -6,29 +6,30 @@ from scipy.stats import rankdata
 
 
 class BackgroundFrequencies(object):
-	@staticmethod
-	def get_background_frequency_df(frequency_path=None):
-		raise Exception
+    @staticmethod
+    def get_background_frequency_df(frequency_path=None):
+        raise Exception
 
-	@classmethod
-	def get_background_rank_df(cls, frequency_path=None):
-		df = cls.get_background_frequency_df(frequency_path)
-		df['rank'] = rankdata(df.background, method='dense')
-		df['background'] = df['rank'] / df['rank'].max()
-		return df[['background']]
+    @classmethod
+    def get_background_rank_df(cls, frequency_path=None):
+        df = cls.get_background_frequency_df(frequency_path)
+        df['rank'] = rankdata(df.background, method='dense')
+        df['background'] = df['rank'] / df['rank'].max()
+        return df[['background']]
 
 
 class DefaultBackgroundFrequencies(BackgroundFrequencies):
-	@staticmethod
-	def get_background_frequency_df(frequency_path=None):
-		if frequency_path:
-			unigram_freq_table_buf = open(frequency_path)
-		else:
-			unigram_freq_table_buf = StringIO(pkgutil.get_data('scattertext', 'data/count_1w.txt')
-			                                  .decode('utf-8'))
-		to_ret = (pd.read_table(unigram_freq_table_buf,
-		                        names=['word', 'background'])
-		          .sort_values(ascending=False, by='background')
-		          .drop_duplicates(['word'])
-		          .set_index('word'))
-		return to_ret
+    @staticmethod
+    def get_background_frequency_df(frequency_path=None):
+        if frequency_path:
+            unigram_freq_table_buf = open(frequency_path)
+        else:
+            unigram_freq_table_buf = StringIO(pkgutil.get_data('scattertext', 'data/count_1w.txt')
+                                              .decode('utf-8'))
+        to_ret = (pd.read_csv(unigram_freq_table_buf,
+                              sep='\t',
+                              names=['word', 'background'])
+                  .sort_values(ascending=False, by='background')
+                  .drop_duplicates(['word'])
+                  .set_index('word'))
+        return to_ret


### PR DESCRIPTION
…ssing sep='\t'

Hi,
First of all thanks for the awesome work.
Since pandas version 0.24 the read_table function is deprecated, so a FutureWarning is issued every time the get_background_frequency_df is called.
The warning recommends using read_csv passing sep='\t' instead of read_table.

This pull request only changes that.