### PR TITLE
Error while loading __init__.py.

### DIFF
--- a/scattertext/__init__.py
+++ b/scattertext/__init__.py
@@ -1656,7 +1656,7 @@ def produce_scattertext_digraph(
         graph_height=500,
         metadata_func=None,
         enable_pan_and_zoom=True,
-        **kwargs,
+        **kwargs
 ):
     graph_df = pd.concat([
         df.assign(


### PR DESCRIPTION
There was an extra comma on line 1659 after kwargs** which caused import errors in Python 3.5.
Let me know if this right!

Thanks :)