### PR TITLE
Add MANIFEST.in to include license file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
I was trying to figure out why the license was packaged previously and then stopped and can't figure it out. Adding this file should solve the issue:

https://packaging.python.org/guides/using-manifest-in/

This should solve https://github.com/JasonKessler/scattertext/issues/37