### PR TITLE
Adding a dashed line instead of a plain one - 45 degrees line

### DIFF
--- a/scattertext/data/viz/scripts/main.js
+++ b/scattertext/data/viz/scripts/main.js
@@ -2050,13 +2050,15 @@ buildViz = function (d3) {
                         .moveToBack();
                 }
             }
-            if (showDiagonal) {
+
+              if (showDiagonal) {
                 var diagonal = svg.append("g")
                     .append("line")
                     .attr("x1", 0)
                     .attr("y1", height)
                     .attr("x2", width)
                     .attr("y2", 0)
+                    .style("stroke-dasharray", "5,5")
                     .style("stroke", "#cccccc")
                     .style("stroke-width", "1px")
                     .moveToBack();


### PR DESCRIPTION
Hi, 

Following our discussion. 
This is a PR to get a 45 degrees **dashed line instead of a plain one** for visual purpose. I think it is **more intuitive** to have a dashed line instead of a plain as it drives the attention back to the data points instead of the line itself which is just a helper here. 😄 

Cheers,
Mastafa