### PR TITLE
Fix deprecation errors

### DIFF
--- a/scattertext/AutoTermSelector.py
+++ b/scattertext/AutoTermSelector.py
@@ -49,7 +49,7 @@ class AutoTermSelector(object):
 		score_terms = AutoTermSelector._get_score_terms(num_term_to_keep, term_doc_freq)
 		background_terms = AutoTermSelector._get_background_terms(num_term_to_keep, term_doc_matrix)
 		frequent_terms = AutoTermSelector._get_frequent_terms(num_term_to_keep, term_doc_freq)
-		terms_to_show = score_terms | background_terms | frequent_terms
+		terms_to_show = score_terms.union(background_terms).union(frequent_terms)
 		return terms_to_show
 
 	@staticmethod
@@ -66,8 +66,8 @@ class AutoTermSelector(object):
 	@staticmethod
 	def _get_score_terms(num_term_to_keep, term_doc_freq):
 		sorted_tdf = term_doc_freq.sort_values(by='score', ascending=False)
-		return (sorted_tdf.iloc[:int(0.25 * num_term_to_keep)].index
-		        | sorted_tdf.iloc[-int(0.25 * num_term_to_keep):].index)
+		return sorted_tdf.iloc[:int(0.25 * num_term_to_keep)].index.union(
+		        sorted_tdf.iloc[-int(0.25 * num_term_to_keep):].index)
 
 	@staticmethod
 	def _add_default_num_terms_to_keep(num_term_to_keep):

--- a/scattertext/CorpusFromTermFrequencies.py
+++ b/scattertext/CorpusFromTermFrequencies.py
@@ -41,7 +41,7 @@ class CorpusFromTermFrequencies(object):
         assert self.X.shape[1] == len(term_vocabulary)
         self.metadata_idx_store = IndexStore()
         if y is None:
-            self.y = np.zeros(self.X.shape[0], dtype=np.int)
+            self.y = np.zeros(self.X.shape[0], dtype=int)
             self.category_idx_store = IndexStoreFromList.build(['_'])
             assert category_names is None
         else:

--- a/scattertext/ScatterChart.py
+++ b/scattertext/ScatterChart.py
@@ -152,7 +152,7 @@ class ScatterChart:
                            rescale_y=None,
                            original_x=None,
                            original_y=None):
-        '''
+        r'''
         Inject custom x and y coordinates for each term into chart.
 
         Parameters
@@ -438,14 +438,14 @@ class ScatterChart:
     def _add_term_freq_to_json_df(self, json_df, term_freq_df, category):
         json_df['cat25k'] = (((term_freq_df[category + ' freq'] * 1.
                                / term_freq_df[category + ' freq'].sum()) * 25000).fillna(0)
-                             .apply(np.round).astype(np.int))
+                             .apply(np.round).astype(int))
         json_df['ncat25k'] = (((term_freq_df['not cat freq'] * 1.
                                 / term_freq_df['not cat freq'].sum()) * 25000).fillna(0)
-                              .apply(np.round).astype(np.int))
+                              .apply(np.round).astype(int))
         if 'neut cat freq' in term_freq_df:
             json_df['neut25k'] = (((term_freq_df['neut cat freq'] * 1.
                                     / term_freq_df['neut cat freq'].sum()) * 25000).fillna(0)
-                                  .apply(np.round).astype(np.int))
+                                  .apply(np.round).astype(int))
             json_df['neut'] = term_freq_df['neut cat freq']
         else:
             json_df['neut25k'] = 0
@@ -453,7 +453,7 @@ class ScatterChart:
         if 'extra cat freq' in term_freq_df:
             json_df['extra25k'] = (((term_freq_df['extra cat freq'] * 1.
                                      / term_freq_df['extra cat freq'].sum()) * 25000).fillna(0)
-                                   .apply(np.round).astype(np.int))
+                                   .apply(np.round).astype(int))
             json_df['extra'] = term_freq_df['extra cat freq']
         else:
             json_df['extra25k'] = 0
@@ -655,7 +655,7 @@ class ScatterChart:
                    .rename(columns={'corpus': 'cat'}))
         json_df['cat25k'] = (((json_df['cat'] * 1.
                                / json_df['cat'].sum()) * 25000)
-                             .apply(np.round).astype(np.int))
+                             .apply(np.round).astype(int))
 
         self._add_x_and_y_coords_to_term_df_if_injected(json_df)
         j = {}

--- a/scattertext/ScatterChartExplorer.py
+++ b/scattertext/ScatterChartExplorer.py
@@ -178,8 +178,8 @@ class ScatterChartExplorer(ScatterChart):
 
     def _add_term_freq_to_json_df(self, json_df, term_freq_df, category):
         ScatterChart._add_term_freq_to_json_df(self, json_df, term_freq_df, category)
-        json_df['cat'] = term_freq_df[category + ' freq'].astype(np.int)
-        json_df['ncat'] = term_freq_df['not cat freq'].astype(np.int)
+        json_df['cat'] = term_freq_df[category + ' freq'].astype(int)
+        json_df['ncat'] = term_freq_df['not cat freq'].astype(int)
         if self._term_metadata is not None:
             json_df['etc'] = term_freq_df['term'].apply(lambda term: self._term_metadata.get(term, {}))
 


### PR DESCRIPTION
- Replace deprecated operator | for Pandas Index with .union method
- Replace deprecated np.int with int
- Raw docstring to avoid unknown escape sequence \i with \in
- Add empty __init__.py for dispersion package