### PR TITLE
Feat: scattertext_structure to matplotlib support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Link to paper: [arxiv.org/abs/1703.00565](https://arxiv.org/abs/1703.00565)
     - [Visualizing topic models](#visualizing-topic-models)
     - [Creating T-SNE-style word embedding projection plots](#creating-T-SNE-style-word-embedding-projection-plots)
     - [Using SVD to visualize any kind of word embeddings](#using-svd-to-visualize-any-kind-of-word-embeddings)
+    - [Exporting plot to matplotlib](#exporting-plot-to-matplotlib)
     - [Using the same scale for both axes](#using-the-same-scale-for-both-axes)
 
 - [Examples](#examples)
@@ -2414,6 +2415,32 @@ html = st.produce_pca_explorer(corpus,
 
 Click for an interactive visualization.  
 [![pca](https://jasonkessler.github.io/svd2.png)](https://jasonkessler.github.io/demo_embeddings_svd_0_1_scale_neg_1_to_1_with_zero_mean.html)
+
+### Exporting plot to matplotlib
+
+To export the content of a scattertext explorer object (ScattertextStructure) to matplotlib you can use `produce_scattertext_pyplot`. The function returns a `matplotlib.figure.Figure` object which can be visualized using `plt.show` or `plt.savefig` as in the example below.
+
+```pydocstring
+convention_df = st.SampleCorpora.ConventionData2012.get_data().assign(
+	parse = lambda df: df.text.apply(st.whitespace_nlp_with_sentences)
+)
+corpus = st.CorpusFromParsedDocuments(convention_df, category_col='party', parsed_col='parse').build()
+scattertext_structure = st.produce_scattertext_explorer(
+	corpus,
+	category='democrat',
+	category_name='Democratic',
+	not_category_name='Republican',
+	minimum_term_frequency=5,
+	pmi_threshold_coefficient=8,
+	width_in_pixels=1000,
+	metadata=convention_df['speaker'],
+	d3_scale_chromatic_url='scattertext/data/viz/scripts/d3-scale-chromatic.v1.min.js',
+	d3_url='scattertext/data/viz/scripts/d3.min.js',
+    return_scatterplot_structure=True,
+)
+st.produce_scattertext_pyplot(scattertext_structure)
+plt.show()
+```
 
 ## Examples 
 

--- a/scattertext/FeatureOuput.py
+++ b/scattertext/FeatureOuput.py
@@ -12,5 +12,5 @@ class FeatureLister(object):
 		toret = [{} for i in range(self.num_docs)]
 		X = self.X.tocoo()
 		for row, col, val in zip(X.row, X.col, X.data):
-			toret[row][self.idx_store.getval(col)] = np.asscalar(val)
+			toret[row][self.idx_store.getval(col)] = val.item()
 		return toret

--- a/scattertext/__init__.py
+++ b/scattertext/__init__.py
@@ -142,6 +142,7 @@ from scattertext.termscoring.LogOddsRatio import LogOddsRatio
 from scattertext.termscoring.RankDifferenceScorer import RankDifferenceScorer
 from scattertext.categorygrouping.CharacteristicGrouper import CharacteristicGrouper
 from scattertext.termscoring.Productivity import ProductivityScorer, whole_corpus_productivity_scores
+from scattertext.viz.PyPlotFromScattertextStructure import pyplot_from_scattertext_structure
 
 PhraseFeatsFromTopicModel = FeatsFromTopicModel  # Ensure backwards compatibility
 
@@ -2110,3 +2111,66 @@ def produce_scattertext_table(
     ).to_html()
 
     return html
+
+
+def produce_scattertext_pyplot(
+    scatterplot_structure,
+    figsize=(15, 7),
+    textsize=7,
+    distance_margin_fraction=0.009,
+    scatter_size=5,
+    cmap="RdYlBu",
+    sample=0,
+    xlabel=None,
+    ylabel=None,
+    dpi=300,
+    draw_lines=False,
+    linecolor="k",
+    draw_all=False,
+    nbr_candidates=0,
+):
+    '''
+    Parameters
+    ----------
+    scatterplot_structure : ScatterplotStructure
+    figsize : Tuple[int,int]
+        Size of ouput pyplot figure
+    textsize : int
+        Size of text terms in plot
+    distance_margin_fraction : float
+        Fraction of the 2d space to use as margins for text bboxes
+    scatter_size : int
+        Size of scatter disks
+    cmap : str
+        Matplotlib compatible colormap
+    sample : int
+        if >0 samples a subset from the scatterplot_structure, used for testing
+    xlabel : str
+        Overrides label from scatterplot_structure
+    ylabel : str
+        Overrides label from scatterplot_structure
+    dpi : int
+        Pyplot figure resolution
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    matplotlib figure that can be used with plt.show() or plt.savefig()
+
+    '''
+    return pyplot_from_scattertext_structure(
+        scatterplot_structure,
+        figsize=figsize,
+        textsize=textsize,
+        distance_margin_fraction=distance_margin_fraction,
+        scatter_size=scatter_size,
+        cmap=cmap,
+        sample=sample,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        dpi=dpi,
+        draw_lines=draw_lines,
+        linecolor=linecolor,
+        draw_all=draw_all,
+        nbr_candidates=nbr_candidates,
+    )

--- a/scattertext/viz/PyPlotFromScattertextStructure.py
+++ b/scattertext/viz/PyPlotFromScattertextStructure.py
@@ -1,0 +1,231 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import random
+import textalloc as ta
+
+
+def pyplot_from_scattertext_structure(
+    scatterplot_structure,
+    figsize,
+    textsize,
+    distance_margin_fraction,
+    scatter_size,
+    cmap,
+    sample,
+    xlabel,
+    ylabel,
+    dpi,
+    draw_lines,
+    linecolor,
+    draw_all,
+    nbr_candidates,
+):
+    """
+    Parameters
+    ----------
+    scatterplot_structure : ScatterplotStructure
+    figsize : Tuple[int,int]
+        Size of ouput pyplot figure
+    textsize : int
+        Size of text terms in plot
+    distance_margin_fraction : float
+        Fraction of the 2d space to use as margins for text bboxes
+    scatter_size : int
+        Size of scatter disks
+    cmap : str
+        Matplotlib compatible colormap string
+    sample : int
+        if >0 samples a subset from the scatterplot_structure, used for testing
+    xlabel : str
+        Overrides label from scatterplot_structure
+    ylabel : str
+        Overrides label from scatterplot_structure
+    dpi : int
+        Pyplot figure resolution
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    matplotlib figure that can be used with plt.show() or plt.savefig()
+
+    """
+    # Extract the data
+    if sample > 0:
+        subset = random.sample(
+            scatterplot_structure._visualization_data.word_dict["data"], sample
+        )
+    else:
+        subset = scatterplot_structure._visualization_data.word_dict["data"]
+    df = pd.DataFrame(subset)
+    if (
+        "etc" in scatterplot_structure._visualization_data.word_dict["data"][0]
+        and "ColorScore"
+        in scatterplot_structure._visualization_data.word_dict["data"][0]["etc"]
+    ):
+        df["s"] = [d["etc"]["ColorScore"] for d in subset]
+    info = scatterplot_structure._visualization_data.word_dict["info"]
+    n_docs = len(scatterplot_structure._visualization_data.word_dict["docs"]["texts"])
+    n_words = df.shape[0]
+
+    if scatterplot_structure._show_characteristic:
+        characteristic_terms = list(
+            df.sort_values("bg", axis=0, ascending=False).iloc[:23].term
+        )
+
+    if df.s.isna().sum() > 0:
+        colors = "k"
+    else:
+        colors = df.s
+
+    # Initiate plotting
+    ax_plot = None
+    if scatterplot_structure._ignore_categories:
+        if scatterplot_structure._show_characteristic:
+            fig, axs = plt.subplots(1, 2, figsize=figsize, width_ratios=[5, 1], dpi=dpi)
+            ax_char = axs[1]
+        else:
+            fig, ax_plot = plt.subplots(1, 1, figsize=figsize, dpi=dpi)
+    else:
+        if scatterplot_structure._show_characteristic:
+            fig, axs = plt.subplots(
+                1, 3, figsize=figsize, width_ratios=[6, 1, 1], dpi=dpi
+            )
+            ax_cat = axs[1]
+            ax_char = axs[2]
+        else:
+            fig, axs = plt.subplots(1, 2, figsize=figsize, width_ratios=[5, 1], dpi=dpi)
+            ax_cat = axs[1]
+    plt.tight_layout()
+    if ax_plot is None:
+        ax_plot = axs[0]
+    ax_plot.scatter(df.x, df.y, c=colors, s=scatter_size, cmap=cmap)
+    xlims = ax_plot.get_xlim()
+    ylims = ax_plot.get_ylim()
+
+    ta.allocate_text(
+        fig,
+        ax_plot,
+        df.x,
+        df.y,
+        df.term,
+        xlims,
+        ylims,
+        x_scatter=df.x,
+        y_scatter=df.y,
+        textsize=textsize,
+        distance_margin_fraction=distance_margin_fraction,
+        draw_lines=draw_lines,
+        linecolor=linecolor,
+        draw_all=draw_all,
+        nbr_candidates=nbr_candidates,
+    )
+
+    # Design settings
+    ax_plot.spines.right.set_visible(False)
+    ax_plot.spines.top.set_visible(False)
+    if xlabel is not None:
+        ax_plot.set_xlabel(xlabel)
+    elif scatterplot_structure._x_label is not None:
+        ax_plot.set_xlabel(scatterplot_structure._x_label)
+    elif not scatterplot_structure._ignore_categories:
+        ax_plot.set_xlabel(info["not_category_name"])
+    else:
+        pass
+    if ylabel is not None:
+        ax_plot.set_ylabel(ylabel)
+    elif scatterplot_structure._y_label is not None:
+        ax_plot.set_ylabel(scatterplot_structure._y_label)
+    elif not scatterplot_structure._ignore_categories:
+        ax_plot.set_ylabel(info["category_name"])
+    else:
+        pass
+    ax_plot.locator_params(axis="y", nbins=3)
+    ax_plot.locator_params(axis="x", nbins=3)
+    try:
+        if scatterplot_structure._x_axis_labels is not None:
+            ax_plot.set_xticks(
+                ax_plot.get_xticks()[1:-1], scatterplot_structure._x_axis_labels, size=7
+            )
+        else:
+            ax_plot.set_xticks(
+                ax_plot.get_xticks()[1:-1], ["Low", "Medium", "High"], size=7
+            )
+    except:
+        pass
+    try:
+        if scatterplot_structure._y_axis_labels is not None:
+            ax_plot.set_yticks(
+                ax_plot.get_yticks()[1:-1],
+                scatterplot_structure._y_axis_labels,
+                size=7,
+                rotation=90,
+            )
+        else:
+            ax_plot.set_yticks(
+                ax_plot.get_yticks()[1:-1],
+                ["Low", "Medium", "High"],
+                size=7,
+                rotation=90,
+            )
+    except:
+        pass
+    if scatterplot_structure._show_diagonal:
+        ax_plot.plot(
+            [xlims[0], xlims[1]],
+            [ylims[0], ylims[1]],
+            color="k",
+            linestyle="dashed",
+            linewidth=1,
+            alpha=0.3,
+        )
+
+    # Categories
+    alignment = {"horizontalalignment": "left", "verticalalignment": "top"}
+    if not scatterplot_structure._ignore_categories:
+        yp = [i / 22 for i in range(22)]
+        yp.reverse()
+        ax_cat.text(
+            0.0,
+            yp[0],
+            "Top " + info["category_name"],
+            weight="bold",
+            size="medium",
+            **alignment,
+        )
+        for i, term in enumerate(info["category_terms"]):
+            ax_cat.text(0.0, yp[i + 1], term, size="small", **alignment)
+        ax_cat.text(
+            0.0,
+            yp[11],
+            "Top " + info["not_category_name"],
+            weight="bold",
+            size="medium",
+            **alignment,
+        )
+        for i, term in enumerate(info["not_category_terms"]):
+            axs[1].text(0.0, yp[i + 12], term, size="small", **alignment)
+        ax_cat.spines.right.set_visible(False)
+        ax_cat.spines.top.set_visible(False)
+        ax_cat.spines.bottom.set_visible(False)
+        ax_cat.spines.left.set_visible(False)
+        ax_cat.set_xticks([])
+        ax_cat.set_yticks([])
+
+    # Characteristics
+    if scatterplot_structure._show_characteristic:
+        yp = [i / 24 for i in range(24)]
+        yp.reverse()
+        ax_char.text(
+            0.0, yp[0], "Characteristic", weight="bold", size="medium", **alignment
+        )
+        for i, term in enumerate(characteristic_terms):
+            ax_char.text(0.0, yp[i + 1], term, size="small", **alignment)
+        ax_char.spines.right.set_visible(False)
+        ax_char.spines.top.set_visible(False)
+        ax_char.spines.bottom.set_visible(False)
+        ax_char.spines.left.set_visible(False)
+        ax_char.set_xticks([])
+        ax_char.set_yticks([])
+
+    fig.suptitle(f"Document count: {n_docs} - Word count: {n_words}", ha="right")
+    return fig

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,10 @@ setup(name='scattertext',
 	      #'empath',
 	      #'umap',
 	      #'gensim'
-	      # 'matplotlib',
+	      'matplotlib',
 	      # 'seaborn',
 	      # 'jupyter',
+            "textalloc",
       ],
       package_data={
 	      'scattertext': ['data/*', 'data/viz/*', 'data/viz/*/*']


### PR DESCRIPTION
Hi,

I was wanting to use this great package with matplotlib to customize plots and due to problems with slow html rendering, so I added support for exporting the ScattertextStructure to matplotlib. I did this by creating my own package for allocating text-boxes in matplotlib plots (https://github.com/ckjellson/textalloc).

I am not sure if this is anything you or anyone else wants, but since I made an implementation I thought I would make this pull request. If you want this feature but don’t want the additional dependency I could import the relevant code from textalloc, otherwise feel free to remove this PR 😊

![output](https://user-images.githubusercontent.com/37980849/199182994-4ae493ae-b86e-4b25-aef1-6f9bbd1cf070.png)
