### PR TITLE
Fix deprecated argument

### DIFF
--- a/scattertext/topicmodel/SentencesForTopicModeling.py
+++ b/scattertext/topicmodel/SentencesForTopicModeling.py
@@ -51,7 +51,7 @@ class SentencesForTopicModeling(object):
 			self,
 			pipe=Pipeline([
 				('tfidf', TfidfTransformer(sublinear_tf=True)),
-				('nmf', (NMF(n_components=30, alpha=.1, l1_ratio=.5, random_state=0)))]),
+				('nmf', (NMF(n_components=30, alpha_W=.1, l1_ratio=.5, random_state=0)))]),
 			num_terms_per_topic=10):
 		'''
 
@@ -60,7 +60,7 @@ class SentencesForTopicModeling(object):
 		pipe : Pipeline
 			For example, `Pipeline([
 				('tfidf', TfidfTransformer(sublinear_tf=True)),
-				('nmf', (NMF(n_components=30, alpha=.1, l1_ratio=.5, random_state=0)))])`
+				('nmf', (NMF(n_components=30, alpha_W=.1, l1_ratio=.5, random_state=0)))])`
 			The last transformer must populate a `components_` attribute when finished.
 		num_terms_per_topic : int
 


### PR DESCRIPTION
# What it does
This PR updates the name of the argument `alpha` to `alpha_W` in the function `get_topics_from_model`.

# Why
Since version 1.2.0, `scikit-learn` deprecated the argument `alpha` for the class `NMF`. This broke `scattertext` as mentioned in #125.

